### PR TITLE
Change agent config output for out of the box use

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,6 @@ The script deploys:
 - A `TestRecipient`. Users can send messages to this contract to verify that everything is working properly.
 
 ```bash
-# The private key that will be used to deploy the contracts. Does not have any
-# permissions post-deployment, any key with a balance will do.
-export PRIVATE_KEY=0x1234
 # The name of the chain to deploy to. Used to configure the localDomain for the
 # Mailbox contract.
 export LOCAL=YOUR_CHAIN_NAME
@@ -52,7 +49,8 @@ export RPC_URL=YOUR_CHAIN_RPC_URL
 # Used to configure the default MultisigIsm.
 export REMOTES=ethereum,polygon,avalanche,celo,arbitrum,optimism,bsc,moonbeam
 
-forge script scripts/DeployCore.s.sol --broadcast --rpc-url $RPC_URL --private-key $PRIVATE_KEY
+# Pass whatever wallet option you would like to use https://book.getfoundry.sh/reference/forge/forge-script#wallet-options---raw
+forge script scripts/DeployCore.s.sol --broadcast --rpc-url $RPC_URL
 ```
 
 ### Deploying a MultisigIsm
@@ -66,9 +64,6 @@ The script will also deploy a `TestRecipient`, configured to use the deployed IS
 ```bash
 # This address will wind up owning the MultisigIsm after it's deployed.
 export OWNER=0x1234
-# The private key that will be used to deploy the contracts. Does not have any
-# permissions post-deployment, any key with a balance will do.
-export PRIVATE_KEY=0x1234
 # An RPC url for the chain to deploy to.
 export RPC_URL=YOUR_CHAIN_RPC_URL
 # The comma separated name(s) of the chain(s) to receive messages from.

--- a/lib/ConfigLib.sol
+++ b/lib/ConfigLib.sol
@@ -58,11 +58,10 @@ library ConfigLib {
         }
     }
 
-    function readHyperlaneDomainConfig(Vm vm, string memory chainName)
-        internal
-        view
-        returns (HyperlaneDomainConfig memory)
-    {
+    function readHyperlaneDomainConfig(
+        Vm vm,
+        string memory chainName
+    ) internal view returns (HyperlaneDomainConfig memory) {
         string memory json = vm.readFile("config/networks.json");
         uint32 domainId = abi.decode(
             vm.parseJson(json, string.concat(chainName, ".id")),
@@ -100,11 +99,10 @@ library ConfigLib {
             );
     }
 
-    function readMultisigIsmDomainConfig(Vm vm, string memory chainName)
-        private
-        view
-        returns (MultisigIsmDomainConfig memory)
-    {
+    function readMultisigIsmDomainConfig(
+        Vm vm,
+        string memory chainName
+    ) private view returns (MultisigIsmDomainConfig memory) {
         string memory json = vm.readFile("config/multisig_ism.json");
         uint8 threshold = abi.decode(
             vm.parseJson(json, string.concat(chainName, ".threshold")),
@@ -131,11 +129,10 @@ library ConfigLib {
             MultisigIsmDomainConfig(chainName, domainId, threshold, validators);
     }
 
-    function readMultisigIsmConfig(Vm vm, string[] memory chainNames)
-        internal
-        view
-        returns (MultisigIsmConfig memory)
-    {
+    function readMultisigIsmConfig(
+        Vm vm,
+        string[] memory chainNames
+    ) internal view returns (MultisigIsmConfig memory) {
         MultisigIsmDomainConfig[]
             memory domains = new MultisigIsmDomainConfig[](chainNames.length);
         for (uint256 i = 0; i < chainNames.length; i++) {

--- a/lib/ConfigLib.sol
+++ b/lib/ConfigLib.sol
@@ -58,10 +58,11 @@ library ConfigLib {
         }
     }
 
-    function readHyperlaneDomainConfig(
-        Vm vm,
-        string memory chainName
-    ) internal view returns (HyperlaneDomainConfig memory) {
+    function readHyperlaneDomainConfig(Vm vm, string memory chainName)
+        internal
+        view
+        returns (HyperlaneDomainConfig memory)
+    {
         string memory json = vm.readFile("config/networks.json");
         uint32 domainId = abi.decode(
             vm.parseJson(json, string.concat(chainName, ".id")),
@@ -99,10 +100,11 @@ library ConfigLib {
             );
     }
 
-    function readMultisigIsmDomainConfig(
-        Vm vm,
-        string memory chainName
-    ) private view returns (MultisigIsmDomainConfig memory) {
+    function readMultisigIsmDomainConfig(Vm vm, string memory chainName)
+        private
+        view
+        returns (MultisigIsmDomainConfig memory)
+    {
         string memory json = vm.readFile("config/multisig_ism.json");
         uint8 threshold = abi.decode(
             vm.parseJson(json, string.concat(chainName, ".threshold")),
@@ -129,10 +131,11 @@ library ConfigLib {
             MultisigIsmDomainConfig(chainName, domainId, threshold, validators);
     }
 
-    function readMultisigIsmConfig(
-        Vm vm,
-        string[] memory chainNames
-    ) internal view returns (MultisigIsmConfig memory) {
+    function readMultisigIsmConfig(Vm vm, string[] memory chainNames)
+        internal
+        view
+        returns (MultisigIsmConfig memory)
+    {
         MultisigIsmDomainConfig[]
             memory domains = new MultisigIsmDomainConfig[](chainNames.length);
         for (uint256 i = 0; i < chainNames.length; i++) {
@@ -183,9 +186,25 @@ library ConfigLib {
             vm.serializeString(index, "from", vm.toString(startBlock))
         );
 
-        vm.serializeString(baseConfig, "name", config.chainName).write(
-            string.concat("./config/", config.chainName, "_agent_config.json")
-        );
+        vm.serializeString(baseConfig, "name", config.chainName);
+
+        vm
+            .serializeString(
+                "topLevel",
+                "chains",
+                vm.serializeString(
+                    "chainLevel",
+                    config.chainName,
+                    vm.serializeString(baseConfig, "protocol", "ethereum")
+                )
+            )
+            .write(
+                string.concat(
+                    "./config/",
+                    config.chainName,
+                    "_agent_config.json"
+                )
+            );
     }
 
     function write(HyperlaneDomainConfig memory config, Vm vm) internal {


### PR DESCRIPTION
This PR slightly changes the output of the agent config so that it can be used when loaded in via `CONFIG_FILES` introduced in https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/1587#issuecomment-1381129481

Drive-by of linking to foundry wallet options and i guess a prettier format