### PR TITLE
Add command to pull down forge submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ For more detailed instructions on how to deploy Hyperlane to the EVM chain of yo
 
   ```bash
   yarn install
+  git submodule init && git submodule update --remote
   ```
 
 ### Deploying core contracts


### PR DESCRIPTION
When running `forge`, I got an error:
```
Compiler run failed
error[6275]: ParserError: Source "lib/forge-std/src/console.sol" not found: File not found. Searched the following locations: "/Users/yiwengao/Documents/hyperlane-deploy".
 --> lib/CheckLib.sol:3:1:
  |
3 | import "../lib/forge-std/src/console.sol";
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
because the `lib/forge-std` directory was empty. I think the `git submodule` commands can also be added the [deploy docs](https://docs.hyperlane.xyz/docs/operators/deployers#1.-deploy-the-core-smart-contracts), but I'm not sure where the source code for v2 is.