### PR TITLE
Use default ISM configuration in more places

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -114,6 +114,10 @@ export function buildIgpConfig(
   owner: types.Address,
   chains: ChainName[],
 ): ChainMap<OverheadIgpConfig> {
+  const mergedMultisigIsmConfig: ChainMap<MultisigIsmConfig> = objMerge(
+    defaultMultisigIsmConfigs,
+    multisigIsmConfig,
+  );
   const configMap: ChainMap<OverheadIgpConfig> = {};
   for (const local of chains) {
     const overhead: ChainMap<number> = {};
@@ -121,8 +125,8 @@ export function buildIgpConfig(
     for (const remote of chains) {
       if (local === remote) continue;
       overhead[remote] = multisigIsmVerificationCost(
-        multisigIsmConfig[remote].threshold,
-        multisigIsmConfig[remote].validators.length,
+        mergedMultisigIsmConfig[remote].threshold,
+        mergedMultisigIsmConfig[remote].validators.length,
       );
       gasOracleType[remote] = GasOracleContractType.StorageGasOracle;
     }

--- a/src/core/HyperlanePermissionlessDeployer.ts
+++ b/src/core/HyperlanePermissionlessDeployer.ts
@@ -13,6 +13,7 @@ import {
   objMap,
   objMerge,
   serializeContractsMap,
+  defaultMultisigIsmConfigs
 } from '@hyperlane-xyz/sdk';
 
 import { multisigIsmConfig } from '../../config/multisig_ism';
@@ -37,7 +38,7 @@ export function getArgs(multiProvider: MultiProvider) {
   //   - ChainMetadata for the MultiProvider
   //   - A MultisigIsmConfig
   const { intersection } = multiProvider.intersect(
-    Object.keys(multisigIsmConfig),
+    Object.keys(multisigIsmConfig).concat(Object.keys(defaultMultisigIsmConfigs)),
   );
 
   return yargs(process.argv.slice(2))

--- a/src/core/HyperlanePermissionlessDeployer.ts
+++ b/src/core/HyperlanePermissionlessDeployer.ts
@@ -10,10 +10,10 @@ import {
   HyperlaneCoreDeployer,
   HyperlaneIgpDeployer,
   MultiProvider,
+  defaultMultisigIsmConfigs,
   objMap,
   objMerge,
   serializeContractsMap,
-  defaultMultisigIsmConfigs
 } from '@hyperlane-xyz/sdk';
 
 import { multisigIsmConfig } from '../../config/multisig_ism';
@@ -38,7 +38,9 @@ export function getArgs(multiProvider: MultiProvider) {
   //   - ChainMetadata for the MultiProvider
   //   - A MultisigIsmConfig
   const { intersection } = multiProvider.intersect(
-    Object.keys(multisigIsmConfig).concat(Object.keys(defaultMultisigIsmConfigs)),
+    Object.keys(multisigIsmConfig).concat(
+      Object.keys(defaultMultisigIsmConfigs),
+    ),
   );
 
   return yargs(process.argv.slice(2))

--- a/src/core/HyperlanePermissionlessDeployer.ts
+++ b/src/core/HyperlanePermissionlessDeployer.ts
@@ -38,9 +38,7 @@ export function getArgs(multiProvider: MultiProvider) {
   //   - ChainMetadata for the MultiProvider
   //   - A MultisigIsmConfig
   const { intersection } = multiProvider.intersect(
-    Object.keys(multisigIsmConfig).concat(
-      Object.keys(defaultMultisigIsmConfigs),
-    ),
+    Object.keys(objMerge(multisigIsmConfig, defaultMultisigIsmConfigs)),
   );
 
   return yargs(process.argv.slice(2))


### PR DESCRIPTION
When deploying between a default chain and a PI chain, there are some places that don't pull the configuration