### PR TITLE
Use default ISM gas paymaster

### DIFF
--- a/src/warp/WarpRouteDeployer.ts
+++ b/src/warp/WarpRouteDeployer.ts
@@ -106,7 +106,8 @@ export class WarpRouteDeployer {
         mailbox: base.mailbox || mergedContractAddresses[baseChainName].mailbox,
         interchainGasPaymaster:
           base.interchainGasPaymaster ||
-          mergedContractAddresses[baseChainName].defaultIsmInterchainGasPaymaster,
+          mergedContractAddresses[baseChainName]
+            .defaultIsmInterchainGasPaymaster,
       },
     };
 

--- a/src/warp/WarpRouteDeployer.ts
+++ b/src/warp/WarpRouteDeployer.ts
@@ -106,7 +106,7 @@ export class WarpRouteDeployer {
         mailbox: base.mailbox || mergedContractAddresses[baseChainName].mailbox,
         interchainGasPaymaster:
           base.interchainGasPaymaster ||
-          mergedContractAddresses[baseChainName].interchainGasPaymaster,
+          mergedContractAddresses[baseChainName].defaultIsmInterchainGasPaymaster,
       },
     };
 

--- a/src/warp/WarpRouteDeployer.ts
+++ b/src/warp/WarpRouteDeployer.ts
@@ -122,7 +122,7 @@ export class WarpRouteDeployer {
           synthetic.mailbox || mergedContractAddresses[sChainName].mailbox,
         interchainGasPaymaster:
           synthetic.interchainGasPaymaster ||
-          mergedContractAddresses[sChainName].interchainGasPaymaster,
+          mergedContractAddresses[sChainName].defaultIsmInterchainGasPaymaster,
       };
     }
     return {


### PR DESCRIPTION
We should use the overheadIgp by default, not the "plain" IGP