### PR TITLE
Corrected the Synthetics Chain property

### DIFF
--- a/src/warp/config.ts
+++ b/src/warp/config.ts
@@ -30,7 +30,7 @@ export type WarpBaseTokenConfig =
 
 export interface WarpRouteConfig {
   base: WarpBaseTokenConfig;
-  synthetics: [WarpSyntheticTokenConfig];
+  synthetics: WarpSyntheticTokenConfig[];
 }
 
 // Zod schema for Warp Route config validation validation


### PR DESCRIPTION
# Current Code
The  synthetic chain property according to the current codebase is 
https://github.com/hyperlane-xyz/hyperlane-deploy/blob/396aa90ab101070d0c2d442184e7d4a23c01f132/src/warp/config.ts#L33

With this codebase, while trying to deploy wrap-route on 2 synthetics chains the `config/warp_tokens.ts` is throwing a compiler error at [line 18](https://github.com/hyperlane-xyz/hyperlane-deploy/blob/396aa90ab101070d0c2d442184e7d4a23c01f132/config/warp_tokens.ts#L18) 

## The config file I created 
```
import { TokenType } from '@hyperlane-xyz/hyperlane-token';

import type { WarpRouteConfig } from '../src/warp/config';

export const warpRouteConfig: WarpRouteConfig = {
  base: {
    chainName: 'zkevm',
    type: TokenType.native,
  },
  synthetics: [
    {
      chainName: 'sepolia',
    },
    {
      chainName: 'mumbai',
    },
  ],
};
```
## The error I am receiving 
```
Type '[{ chainName: string; }, { chainName: string; }]' is not assignable to type '[WarpSyntheticTokenConfig]'.
  Source has 2 element(s) but target allows only 1.ts(2322)
config.ts(33, 3): The expected type comes from property 'synthetics' which is declared here on type 'WarpRouteConfig'
```
---

# Correct Code
The  synthetic chain property in `src/warp/config.ts` at line 33:
https://github.com/hyperlane-xyz/hyperlane-deploy/blob/396aa90ab101070d0c2d442184e7d4a23c01f132/src/warp/config.ts#L33 
should be 
```
  synthetics: WarpSyntheticTokenConfig[];
```

---

# Test 
For the testing, 

I have deployed the wrap route token with the following command:
```
DEBUG=hyperlane* yarn ts-node scripts/deploy-warp-routes.ts \
  --key   
  ```
Referred from the [docs](https://docs.hyperlane.xyz/docs/deploy/deploy-warp-route/deploy-a-warp-route#4.-testing).

## The Result 
```
 hyperlane Warp route deployment completed successfully +6m
 ```
