### PR TITLE
feat: deploy warp router for erc721

### DIFF
--- a/config/warp_tokens.ts
+++ b/config/warp_tokens.ts
@@ -11,6 +11,7 @@ export const warpRouteConfig: WarpRouteConfig = {
     type: TokenType.native, //  TokenType.native or TokenType.collateral
     // If type is collateral, a token address is required:
     // address: '0x123...'
+    // isERC721: boolean // require
 
     // Optionally, specify owner, mailbox, and interchainGasPaymaster addresses
     // If not specified, the Permissionless Deployment artifacts or the SDK's defaults will be used

--- a/src/warp/config.ts
+++ b/src/warp/config.ts
@@ -15,6 +15,7 @@ export interface WarpNativeTokenConfig extends WarpBaseToken {
 export interface WarpCollateralTokenConfig extends WarpBaseToken {
   type: TokenType.collateral;
   address: string;
+  isERC721: boolean;
 }
 
 export type WarpSyntheticTokenConfig = {

--- a/src/warp/types.ts
+++ b/src/warp/types.ts
@@ -1,9 +1,14 @@
 import type { TokenType } from '@hyperlane-xyz/hyperlane-token';
 // TODO get properly exported from hyp-token
-import { ERC20Metadata } from '@hyperlane-xyz/hyperlane-token/dist/config';
 import type { types } from '@hyperlane-xyz/utils';
+import { ethers } from 'ethers';
 
-export type TokenMetadata = Omit<ERC20Metadata, 'totalSupply'>;
+export type TokenMetadata = {
+  name: string;
+  symbol: string;
+  totalSupply?: ethers.BigNumberish;
+  decimals?: number;
+};
 
 // Types below must match the warp ui token config schema
 // https://github.com/hyperlane-xyz/hyperlane-warp-ui-template/blob/main/src/features/tokens/types.ts


### PR DESCRIPTION
# What
i add new feature to able to deploy warpRoute for erc721
# New
## Note
ERC721 contract should have totalSupply() if not it will failed because HypERC721Deployer.fetchMetadata() of hyperlane-token package require it
## configuration
We need to add isERC721 to WarpRouteConfig base if you want to use erc721 as collateral

```
export const warpRouteConfig: WarpRouteConfig = {
  base: {
    // Chain name must be in the Hyperlane SDK or in the chains.ts config
    chainName: 'goerli',
    type: TokenType.collateral, //  TokenType.native or TokenType.collateral
    // If type is collateral, a token address is required:
    // address: '0x123...'
    // isERC721:  boolean

    // Optionally, specify owner, mailbox, and interchainGasPaymaster addresses
    // If not specified, the Permissionless Deployment artifacts or the SDK's defaults will be used
  },
```

# Reference:
https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/2201