### PR TITLE
Update test-warp-transfer.ts

### DIFF
--- a/scripts/test-warp-transfer.ts
+++ b/scripts/test-warp-transfer.ts
@@ -154,7 +154,10 @@ run('Warp transfer test', async () => {
     case TokenType.collateral: {
       const router = app.getContracts(origin).router as HypERC20Collateral;
       const tokenAddress = await router.wrappedToken();
-      const token = ERC20__factory.connect(tokenAddress, signer);
+      const token = ERC20__factory.connect(
+        tokenAddress,
+        multiProvider.getSigner(origin),
+      );
       const approval = await token.allowance(
         await signer.getAddress(),
         router.address,


### PR DESCRIPTION
 I was testing warp route and I got:

```
$ yarn ts-node scripts/test-warp-transfer.ts \ 
  --origin mumbai --destination snapchain --wei 123 \
  --recipient 0x9DA155Af6926eBbb72Bce91fD84efE8fC867274c \
  --key <REDACTED>


...
hyperlane:ERROR Error running Warp transfer test Error: missing provider (operation="call", code=UNSUPPORTED_OPERATION, version=abstract-signer/5.7.0)
```

after discussing with @nambrot offline, this is the suggested fix